### PR TITLE
Corrected data type in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ The training classes should be in matrix form, where the ith row corresponds to
 
 // create training data and target values
 int rows, features, classes;
-double** training;
-double** classes;
+float** training;
+float** classes;
 
 // create matrices to hold the data
 Matrix* trainingData = createMatrix(rows, features, training);


### PR DESCRIPTION
The example provided in [`README.md`](https://github.com/100/Cranium/blob/master/README.md) shows the training data being provided as `double**` type rather than `float**`.  A minor mistake (I think?), but one that might confuse people trying to use the project.

(Incidentally, it might be worth adding a comment into the example that the user should actually load data into `training` and `classes`)